### PR TITLE
Show latest publications on homepage

### DIFF
--- a/_includes/selected_papers.html
+++ b/_includes/selected_papers.html
@@ -1,4 +1,5 @@
 
           <div class="publications">
-            {% bibliography -f {{ site.scholar.bibliography }} --group_by none --query @*[selected=true]* %}
+            {% bibliography -f {{ site.scholar.bibliography }} --group_by none --query @* --sort_by year,month,day --order descending --max 5 %}
           </div>
+          <p><a href="{{ '/publications/' | relative_url }}">Show all publications</a></p>

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -53,9 +53,9 @@ layout: default
             {%- include latest_posts.html %}
           {%- endif %}
 
-          <!-- Selected papers -->
+          <!-- Latest publications -->
           {% if page.selected_papers -%}
-            <h2><a href="{{ '/publications/' | relative_url }}" style="color: inherit;">selected publications</a></h2>
+            <h2><a href="{{ '/publications/' | relative_url }}" style="color: inherit;">latest publications</a></h2>
             {%- include selected_papers.html %}
           {%- endif %}
 


### PR DESCRIPTION
## Summary
- Sort and display the five most recent publications on the homepage
- Provide a direct "Show all publications" link under the latest list

## Testing
- `bundle exec jekyll build` *(interrupted: jekyll-imagemagick generating image assets)*

------
https://chatgpt.com/codex/tasks/task_e_68906a58639c8333b6b86ebef65ea729