### PR TITLE
Show latest publications on homepage

### DIFF
--- a/_includes/selected_papers.html
+++ b/_includes/selected_papers.html
@@ -1,4 +1,4 @@
-
           <div class="publications">
-            {% bibliography -f {{ site.scholar.bibliography }} --group_by none --query @*[selected=true]* %}
+            {% bibliography -f {{ site.scholar.bibliography }} --query @*[year=2025] %}
           </div>
+          <p><a href="{{ '/publications/' | relative_url }}">Show all publications</a></p>

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -53,9 +53,9 @@ layout: default
             {%- include latest_posts.html %}
           {%- endif %}
 
-          <!-- Selected papers -->
+          <!-- Latest publications -->
           {% if page.selected_papers -%}
-            <h2><a href="{{ '/publications/' | relative_url }}" style="color: inherit;">selected publications</a></h2>
+            <h2><a href="{{ '/publications/' | relative_url }}" style="color: inherit;">latest publications</a></h2>
             {%- include selected_papers.html %}
           {%- endif %}
 


### PR DESCRIPTION
## Summary
- Filter homepage publications list for entries from 2025 only
- Keep link to full publications archive under the list

## Testing
- `sudo apt-get install -y imagemagick`
- `bundle install`
- `bundle exec jekyll build` *(interrupted while ImageMagick generated images)*

------
https://chatgpt.com/codex/tasks/task_e_68906a58639c8333b6b86ebef65ea729