### PR TITLE
Refine homepage structured data: split name fields, honorific, add AboutPage and mainEntity

### DIFF
--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -137,7 +137,11 @@
             {
                 "@type": "Person",
                 "@id": "{{ person_id }}",
-                "name": {{ "Prof. Dr. Florian Müller" | jsonify }},
+                "name": {{ "Florian Müller" | jsonify }},
+                "honorificPrefix": {{ "Prof. Dr." | jsonify }},
+                "givenName": {{ "Florian" | jsonify }},
+                "familyName": {{ "Müller" | jsonify }},
+                "alternateName": {{ "Florian Mueller" | jsonify }},
                 "url": {{ homepage_url | jsonify }},
                 "image": {{ site.og_image | jsonify }},
                 "jobTitle": {{ "Assistant Professor for Mobile Human-Computer Interaction" | jsonify }},
@@ -155,7 +159,7 @@
             },
             {%- endif -%}
             {
-                "@type": "WebPage",
+                "@type": {% if is_homepage %}["WebPage", "AboutPage"]{% else %}"WebPage"{% endif %},
                 "@id": "{{ page_url }}#webpage",
                 "url": {{ page_url | jsonify }},
                 "name": {{ page_name | jsonify }},
@@ -165,7 +169,10 @@
                 },
                 "about": {
                     "@id": "{{ person_id }}"
-                }{% if page_image != "" %},
+                }{% if is_homepage %},
+                "mainEntity": {
+                    "@id": "{{ person_id }}"
+                }{% endif %}{% if page_image != "" %},
                 "primaryImageOfPage": {
                     "@type": "ImageObject",
                     "@id": "{{ page_url }}#primaryimage",


### PR DESCRIPTION
### Motivation
- Make the homepage `Person` schema more explicit so search engines and profile consumers can better identify the person represented on the page. 
- Improve name matching and disambiguation by separating the honorific and name parts and providing an ASCII alternative. 
- Clarify page intent by marking the homepage as an `AboutPage` and explicitly linking the page `mainEntity` to the `Person` entity. 

### Description
- Replaced the combined honorific + name with `name` set to `"Florian Müller"` and added `honorificPrefix`, `givenName`, `familyName`, and `alternateName` in `_includes/metadata.html`.
- When `is_homepage` the `WebPage` `@type` is now `["WebPage", "AboutPage"]` and the page object includes a `mainEntity` referencing the `Person` by `@id`.
- Retained the existing `publisher` and `sameAs` references while using the `Person` `@id` to reduce duplication.
- All changes are confined to the `_includes/metadata.html` Schema.org JSON-LD block.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967b295f9808333854ba0433523dc10)