### PR TITLE
Make `alternateName` an array, add `affiliation`, and update About title

### DIFF
--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -141,11 +141,16 @@
                 "honorificPrefix": {{ "Prof. Dr." | jsonify }},
                 "givenName": {{ "Florian" | jsonify }},
                 "familyName": {{ "Müller" | jsonify }},
-                "alternateName": {{ "Florian Mueller" | jsonify }},
+                "alternateName": [{{ "Florian Mueller" | jsonify }}],
                 "url": {{ homepage_url | jsonify }},
                 "image": {{ site.og_image | jsonify }},
                 "jobTitle": {{ "Assistant Professor for Mobile Human-Computer Interaction" | jsonify }},
                 "worksFor": {
+                    "@type": "CollegeOrUniversity",
+                    "name": {{ "TU Darmstadt" | jsonify }},
+                    "url": {{ "https://www.tu-darmstadt.de/" | jsonify }}
+                },
+                "affiliation": {
                     "@type": "CollegeOrUniversity",
                     "name": {{ "TU Darmstadt" | jsonify }},
                     "url": {{ "https://www.tu-darmstadt.de/" | jsonify }}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,6 @@
 ---
 layout: about
-title: about
+title: Florian Müller — About
 permalink: /
 subtitle: urban interaction · hci4ai · ar/vr enthusiast · statistics nerd
 


### PR DESCRIPTION
### Motivation
- Improve the JSON-LD Person schema so parsers/knowledge systems receive `alternateName` as an array and gain a common `affiliation` field for TU Darmstadt.
- Make the About page title more descriptive for clarity and slight SEO/readability improvement.

### Description
- Change `alternateName` from a plain string to an array in `_includes/metadata.html` (`"alternateName": ["Florian Mueller"]`).
- Add a `affiliation` entry mirroring the existing `worksFor` `CollegeOrUniversity` block in `_includes/metadata.html` for TU Darmstadt.
- Update the About page `title` to `Florian Müller — About` in `_pages/about.md`.

### Testing
- Ran `bundle install` to provision gems and it completed successfully.
- Attempted to run `bundle exec jekyll serve --host 0.0.0.0 --port 4000`, but site build did not complete successfully because ImageMagick `convert` was missing and image generation failed, preventing the server from becoming reachable.
- Automated page screenshot attempt (Playwright) failed because the local server was not reachable due to the build/image tool failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967b89bbbbc833386545ca32e01fe53)