### PR TITLE
Add OG meta improvements and /publications/ redirects

### DIFF
--- a/scripts/parse_bib.py
+++ b/scripts/parse_bib.py
@@ -463,6 +463,7 @@ def main():
             f"title = {json.dumps(pub['title'])}",
             f"date = {json.dumps(date_str)}",
             "type = \"publication\"",
+            f"aliases = [\"/publications/{pub['key']}/\"]",
             f"authors = {json.dumps(pub['authors'])}",
             f"authors_html = {json.dumps(pub['authors_html'])}",
             f"venue = {json.dumps(pub['venue'])}",


### PR DESCRIPTION
- Fix og:image to use publication preview image instead of profile photo
- Fix og:description to use abstract summary instead of site description
- Add Hugo aliases so /publications/<slug>/ redirects to /publication/<slug>/
- Automate alias generation in parse_bib.py for new papers